### PR TITLE
Update install.ps1: nb alias runs jupyter in background

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -83,7 +83,7 @@ function m269-23j {
     $VENV\Scripts\Activate.ps1
 }
 function nb {
-    jupyter notebook $FOLDER
+    Start-process -NoNewWindow jupyter -ArgumentList "notebook $FOLDER"
 }
 function allowed {
     param(


### PR DESCRIPTION
Jupyter will now run in the background with the `nb` alias on Windows. I have _not_ changed the `README` file or any instructions.