### PR TITLE
Unix: add uninstall.sh and update install.sh to modify it during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,19 +173,20 @@ else
 fi
 
 # Set variables in uninstall.sh
-# Mac and Linux use different version of sed, so need different syntax.
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+if [[ -f "$FOLDER/$UNINSTALL" ]]; then
     echo "Setting variables in uninstall.sh ..."
-    sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
-    sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Setting variables in uninstall.sh ..."
-    sed -i "" -e "14i\\" -e "FOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
-    sed -i "" -e "15i\\" -e "SHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
+    # Insert FOLDER variable at line 14
+    sed "14i\\
+FOLDER=$FOLDER" "$FOLDER/$UNINSTALL" > "$FOLDER/$UNINSTALL.tmp"
+    mv "$FOLDER/$UNINSTALL.tmp" "$FOLDER/$UNINSTALL"
+    # Insert SHELL_CONFIG_FILE variable at line 15
+    sed "15i\\
+SHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL" > "$FOLDER/$UNINSTALL.tmp"
+    mv "$FOLDER/$UNINSTALL.tmp" "$FOLDER/$UNINSTALL"
+    chmod +x "$FOLDER/$UNINSTALL"
 else
-    echo "Warning: unknown OS or OSTYPE environment variable has been changed."
-    echo "unable to set variables in uninstall.sh..."
+    echo "Warning: $FOLDER/$UNINSTALL does not exist."
+    echo "Unable to set variables in uninstall.sh..."
 fi
-chmod +x "$FOLDER/$UNINSTALL"
 
 echo "All done. Go to $SITE for further instructions."

--- a/install.sh
+++ b/install.sh
@@ -173,9 +173,17 @@ else
 fi
 
 # Set variables in uninstall.sh
+# Mac os uses BSD version of sed so needs different syntax.
 echo "Setting variables into uninstall.sh ..."
-sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
-sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
+    sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" -e "14i\\" -e "FOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
+    sed -i "" -e "15i\\" -e "SHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
+else
+    echo "Warning: unknown OS, unable to set variables into uninstall.sh"
+fi
 chmod +x "$FOLDER/$UNINSTALL"
 
 echo "All done. Go to $SITE for further instructions."

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ CHECK="allowed.py m269.json"
 FILES="$CSS $REQS $CHECK"
 COURSE=m269-23j
 VENV=~/venvs/$COURSE
+CONFIG_VARS=("VENV" "COURSE")
 
 # find out under which shell this script is running
 parent_shell=$(ps -o command $PPID)
@@ -120,6 +121,8 @@ else
     cp -a $CHECK "$FOLDER"
 fi
 
+CONFIG_VARS+=("FOLDER")
+
 echo "Creating Python environment $VENV... (this will take a bit)"
 python3.10 -m venv --prompt $COURSE $VENV
 
@@ -139,25 +142,36 @@ ALLOWED="python3.10 \"$FOLDER/allowed.py\" -c \"$FOLDER/m269.json\""
 
 if [ $shell = "fish" ]
 then
-    FILE=~/.config/fish/config.fish
+    SHELL_CONFIG_FILE=~/.config/fish/config.fish
 else
-    FILE=~/.${shell}rc
+    SHELL_CONFIG_FILE=~/.${shell}rc
 fi
+
+CONFIG_VARS+=("SHELL_CONFIG_FILE")
 
 if [ $shell = "csh" ] || [ $shell = "tcsh" ]
 then
-    echo "alias $COURSE '$M269.csh'" >> $FILE
-    echo "alias nb '$NB'" >> $FILE
-    echo "alias allowed '$ALLOWED'" >> $FILE
+    echo "alias $COURSE '$M269.csh'" >> $SHELL_CONFIG_FILE
+    echo "alias nb '$NB'" >> $SHELL_CONFIG_FILE
+    echo "alias allowed '$ALLOWED'" >> $SHELL_CONFIG_FILE
 else
     if [ $shell = "fish" ]
     then
-        echo "alias $COURSE='$M269.fish'" >> $FILE
+        echo "alias $COURSE='$M269.fish'" >> $SHELL_CONFIG_FILE
     else
-        echo "alias $COURSE='$M269'" >> $FILE
+        echo "alias $COURSE='$M269'" >> $SHELL_CONFIG_FILE
     fi
-    echo "alias nb='$NB'" >> $FILE
-    echo "alias allowed='$ALLOWED'" >> $FILE
+    echo "alias nb='$NB'" >> $SHELL_CONFIG_FILE
+    echo "alias allowed='$ALLOWED'" >> $SHELL_CONFIG_FILE
 fi
+
+M269_CONFIG_FILE=$FOLDER/.m269rc
+CONFIG_VARS+=("M269_CONFIG_FILE")
+
+# Write the name=value pairs to m269 config file
+for var_name in "${CONFIG_VARS[@]}"; do
+    var_value="${!var_name}"
+    echo "$var_name=$var_value" >> "$M269_CONFIG_FILE"
+done
 
 echo "All done. Go to $SITE for further instructions."

--- a/install.sh
+++ b/install.sh
@@ -18,10 +18,10 @@ DOC="See $SITE for details."
 CSS=custom.css
 REQS=requirements.txt
 CHECK="allowed.py m269.json"
-FILES="$CSS $REQS $CHECK"
+UNINSTALL=uninstall.sh
+FILES="$CSS $REQS $CHECK $UNINSTALL"
 COURSE=m269-23j
 VENV=~/venvs/$COURSE
-UNINSTALL=uninstall.sh
 
 # find out under which shell this script is running
 parent_shell=$(ps -o command $PPID)
@@ -90,6 +90,11 @@ then
         do
             # WARNING: CHANGE URL BACK TO MAIN BRANCH BEFORE MERGING!!!
             curl -LO https://github.com/dsa-ou/m269-installer/raw/14-create-uninstallation-scripts/$file
+            if [ $? -ne 0 ]
+            then
+                echo "Failed to download $file"
+                exit 1
+            fi
         done
     mkdir -p ~/.jupyter/custom
     # don't overwrite existing CSS file
@@ -120,6 +125,11 @@ else
         cp -a $CSS ~/.jupyter/custom
     fi
     cp -a $CHECK $UNINSTALL "$FOLDER"
+    if [ $? -ne 0 ]
+    then
+        echo "Failed to copy $CHECK and $UNINSTALL"
+        exit 1
+    fi
 fi
 
 echo "Creating Python environment $VENV... (this will take a bit)"
@@ -163,15 +173,9 @@ else
 fi
 
 # Set variables in uninstall.sh
-if [[ -f "$FOLDER/$UNINSTALL" ]]
-then
-    echo "Setting variables into uninstall.sh ..."
-    sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
-    sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
-    chmod +x "$FOLDER/$UNINSTALL"
-else
-    echo "Warning: $FOLDER/uninstall.sh does not exist."
-    echo "critical Variables have not been set in uninstall.sh."
-fi
+echo "Setting variables into uninstall.sh ..."
+sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
+sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
+chmod +x "$FOLDER/$UNINSTALL"
 
 echo "All done. Go to $SITE for further instructions."

--- a/install.sh
+++ b/install.sh
@@ -173,16 +173,18 @@ else
 fi
 
 # Set variables in uninstall.sh
-# Mac os uses BSD version of sed so needs different syntax.
-echo "Setting variables into uninstall.sh ..."
+# Mac and Linux use different version of sed, so need different syntax.
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "Setting variables in uninstall.sh ..."
     sed -i "14iFOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
     sed -i "15iSHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Setting variables in uninstall.sh ..."
     sed -i "" -e "14i\\" -e "FOLDER=$FOLDER" "$FOLDER/$UNINSTALL"
     sed -i "" -e "15i\\" -e "SHELL_CONFIG_FILE=$SHELL_CONFIG_FILE" "$FOLDER/$UNINSTALL"
 else
-    echo "Warning: unknown OS, unable to set variables into uninstall.sh"
+    echo "Warning: unknown OS or OSTYPE environment variable has been changed."
+    echo "unable to set variables in uninstall.sh..."
 fi
 chmod +x "$FOLDER/$UNINSTALL"
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+BOLD="\033[1m"
+NORMAL="\033[0m"
+
+confirm() {
+    local message="$1"
+    echo -en "${BOLD}:: $message [y/N] ${NORMAL}"
+    read -r response
+    case "$response" in
+        [yY])
+            return 0  # true
+            ;;
+        *)
+            return 1  # false
+            ;;
+    esac
+}
+
+# Confirm uninstallation
+echo "Warning: After uninstallation, you will need a Jupyter environment to open and run your notebooks."
+if ! confirm "Proceed with uninstallation?"; then
+    exit 1
+fi
+
+# Assume variables VENV, COURSE, FOLDER, SHELL_CONFIG_FILE,
+# will be in the M269 config file
+if [ -e .m269rc ]; then
+    source .m269rc
+else
+    echo "Failed to source the M269 configuration file "
+    exit 1
+fi
+CSS_FILE=~/.jupyter/custom/custom.css
+COURSE_YEAR="${COURSE:5:2}"
+
+# Remove the virtual environment
+remove_venv() {
+    test -n "$VENV" || return 1
+    test -d "$VENV" || return 1
+    # Check for existence of typical virtual environment files
+    test -f "$VENV/bin/activate" || return 1
+    test -f "$VENV/pyvenv.cfg" || return 1
+    echo "Removing the virtual environment..."
+    rm -r "$VENV"
+}
+if confirm "Remove the $COURSE virtual environment?"; then
+    remove_venv || echo "Warning: failed to remove the virtual environment."
+fi
+
+# Remove allowed.py and m269.json from M269 folder
+if confirm "Remove allowed.py and m269.json from $FOLDER ?"; then
+    for file in "allowed.py" "m269.json"; do
+        target="$FOLDER/$file"
+        if [ -e "$target" ]; then
+            echo "Removing $file from $FOLDER..."
+            rm "$target"
+        else
+            echo "Warning: $target does not exist."
+        fi
+    done
+fi
+
+# Remove aliases from the configuration file
+if confirm "Remove shortcut commands from $SHELL_CONFIG_FILE ?"; then
+    ALIASES=("alias nb" "alias allowed" "alias $COURSE")
+    if [ -e $SHELL_CONFIG_FILE ]; then
+        echo "Removing shortcut commands from $SHELL_CONFIG_FILE..."
+        cp "$SHELL_CONFIG_FILE" "$SHELL_CONFIG_FILE".backup
+        for alias in "${ALIASES[@]}"; do
+            # Delete lines that start with $alias and contain current course "code"
+            sed -i "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
+        done
+    fi
+fi
+
+# Remove lines from ~/.jupyter/custom/custom.css
+if confirm "Remove M269 custom styling from $CSS_FILE ?"; then
+    # Special characters need to be escaped for use in regex
+    START_DELIM="\/\* Start of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
+    END_DELIM="\/\* End of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
+    if [ -e $CSS_FILE ]; then
+        cp "$CSS_FILE" "$CSS_FILE".backup
+        echo "Removing M269 custom styling from $CSS_FILE..."
+        sed -i "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
+    fi
+
+fi
+
+echo "The uninstallation process has now completed."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,40 +1,55 @@
 #!/bin/bash
 
+# This script performs the uninstallation of the M269 course environment
+# and will do the following:
+# - Seeks user confirmation before proceeding.
+# - Deletes the M269 virtual environment.
+# - Erases course-specific aliases from the shell config file.
+# - Removes files related to `allowed` from the M269 folder.
+# - Optionally clears M269 styling from Jupyter's custom.css.
+
+# Note: this script expects FOLDER and SHELL_CONFIG_FILE to be set during the
+# installation process (inserted with sed via install.sh).
+
+COURSE=m269-23j
+VENV=~/venvs/$COURSE
+CSS_FILE=~/.jupyter/custom/custom.css
+COURSE_YEAR=23
+SITE=https://dsa-ou.github.io/m269-installer
+
+# Check FOLDER and SHELL_CONFIG_FILE have been set i.e inserted via install.sh
+if [[ -z "$FOLDER" ]] || [[ -z "$SHELL_CONFIG_FILE" ]]; then
+    echo "Error: critical variables have not been set"
+    exit 1
+fi
+
 BOLD="\033[1m"
 NORMAL="\033[0m"
-
 confirm() {
     local message="$1"
     echo -en "${BOLD}:: $message [y/N] ${NORMAL}"
     read -r response
     case "$response" in
         [yY])
-            return 0  # true
+            return 0
             ;;
         *)
-            return 1  # false
+            return 1
             ;;
     esac
 }
 
 # Confirm uninstallation
-echo "Warning: After uninstallation, you will need a Jupyter environment to open and run your notebooks."
+echo "Warning: This script will make the following changes: "
+echo " - Remove the virtual environment in $VENV."
+echo " - Remove the aliases 'nb', 'allowed' and '$COURSE' from $SHELL_CONFIG_FILE"
+echo " - Optionally removes M269 custom styling from $CSS_FILE"
+echo "As a result, Jupyter notebooks will no longer be readable or executable unless another Jupyter environment exists."
 if ! confirm "Proceed with uninstallation?"; then
-    exit 1
+    exit 0
 fi
 
-# Assume variables VENV, COURSE, FOLDER, SHELL_CONFIG_FILE,
-# will be in the M269 config file
-if [ -e .m269rc ]; then
-    source .m269rc
-else
-    echo "Failed to source the M269 configuration file "
-    exit 1
-fi
-CSS_FILE=~/.jupyter/custom/custom.css
-COURSE_YEAR="${COURSE:5:2}"
-
-# Remove the virtual environment
+# Verify and remove the virtual environment.
 remove_venv() {
     test -n "$VENV" || return 1
     test -d "$VENV" || return 1
@@ -44,34 +59,30 @@ remove_venv() {
     echo "Removing the virtual environment..."
     rm -r "$VENV"
 }
-if confirm "Remove the $COURSE virtual environment?"; then
-    remove_venv || echo "Warning: failed to remove the virtual environment."
-fi
+remove_venv || { echo "Error: failed to remove the virtual environment."; exit 1; }
 
 # Remove allowed.py and m269.json from M269 folder
-if confirm "Remove allowed.py and m269.json from $FOLDER ?"; then
-    for file in "allowed.py" "m269.json"; do
-        target="$FOLDER/$file"
-        if [ -e "$target" ]; then
-            echo "Removing $file from $FOLDER..."
-            rm "$target"
-        else
-            echo "Warning: $target does not exist."
-        fi
-    done
-fi
+for file in "allowed.py" "m269.json"; do
+    target="$FOLDER/$file"
+    if [[ -f "$target" ]]; then
+        echo "Removing $file from $FOLDER..."
+        rm "$target"
+    else
+        echo "Warning: $target does not exist."
+    fi
+done
 
 # Remove aliases from the configuration file
-if confirm "Remove shortcut commands from $SHELL_CONFIG_FILE ?"; then
-    ALIASES=("alias nb" "alias allowed" "alias $COURSE")
-    if [ -e $SHELL_CONFIG_FILE ]; then
-        echo "Removing shortcut commands from $SHELL_CONFIG_FILE..."
-        cp "$SHELL_CONFIG_FILE" "$SHELL_CONFIG_FILE".backup
-        for alias in "${ALIASES[@]}"; do
-            # Delete lines that start with $alias and contain current course "code"
-            sed -i "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
-        done
-    fi
+ALIASES=("alias nb" "alias allowed" "alias $COURSE")
+if [[ -f "$SHELL_CONFIG_FILE" ]]; then
+    echo "Removing shortcut commands from $SHELL_CONFIG_FILE..."
+    cp "$SHELL_CONFIG_FILE" "$SHELL_CONFIG_FILE".backup
+    for alias in "${ALIASES[@]}"; do
+        # Delete lines that start with $alias and contain current course "code"
+        sed -i "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
+    done
+else
+    echo "Warning: $SHELL_CONFIG_FILE does not exist."
 fi
 
 # Remove lines from ~/.jupyter/custom/custom.css
@@ -79,12 +90,13 @@ if confirm "Remove M269 custom styling from $CSS_FILE ?"; then
     # Special characters need to be escaped for use in regex
     START_DELIM="\/\* Start of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
     END_DELIM="\/\* End of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
-    if [ -e $CSS_FILE ]; then
+    if [[ -f "$CSS_FILE" ]]; then
         cp "$CSS_FILE" "$CSS_FILE".backup
         echo "Removing M269 custom styling from $CSS_FILE..."
         sed -i "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
+    else
+        echo "Warning: $CSS_FILE does not exist."
     fi
-
 fi
 
-echo "The uninstallation process has now completed."
+echo "All done. To reinstall please visit $SITE and follow the provided instructions."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -79,7 +79,13 @@ if [[ -f "$SHELL_CONFIG_FILE" ]]; then
     cp "$SHELL_CONFIG_FILE" "$SHELL_CONFIG_FILE".backup
     for alias in "${ALIASES[@]}"; do
         # Delete lines that start with $alias and contain current course "code"
-        sed -i "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            sed -i "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
+        elif [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i "" "/^$alias.*[Mm]269-$COURSE_YEAR[Jj]/d" "$SHELL_CONFIG_FILE"
+        else
+            echo "Warning: unknown OS, skipping alias removal."
+        fi
     done
 else
     echo "Warning: $SHELL_CONFIG_FILE does not exist."
@@ -87,13 +93,18 @@ fi
 
 # Remove lines from ~/.jupyter/custom/custom.css
 if confirm "Remove M269 custom styling from $CSS_FILE ?"; then
-    # Special characters need to be escaped for use in regex
     START_DELIM="\/\* Start of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
     END_DELIM="\/\* End of [Mm]269-$COURSE_YEAR[Jj] notebook styling. \*\/"
     if [[ -f "$CSS_FILE" ]]; then
         cp "$CSS_FILE" "$CSS_FILE".backup
         echo "Removing M269 custom styling from $CSS_FILE..."
-        sed -i "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            sed -i "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
+        elif [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i "" "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
+        else
+            echo "Warning: unknown OS, skipping custom styling removal."
+        fi
     else
         echo "Warning: $CSS_FILE does not exist."
     fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -83,14 +83,8 @@ if [[ -f "$SHELL_CONFIG_FILE" ]]; then
     for alias in "${ALIASES[@]}"; do
         # Pattern is: Start with $alias, and contains $COURSE_PATTERN or $NB in rest of line.
         alias_pattern="/^$alias.*\(\($COURSE_PATTERN\)\|\($NB\)\)/d"
-        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            sed -i "$alias_pattern" "$SHELL_CONFIG_FILE"
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i "" "$alias_pattern" "$SHELL_CONFIG_FILE"
-        else
-            echo "Warning: unknown OS or OSTYPE environment variable has been changed."
-            echo "skipping removal of shortcut commands..."
-        fi
+        sed "$alias_pattern" "$SHELL_CONFIG_FILE" > "$SHELL_CONFIG_FILE.tmp"
+        mv "$SHELL_CONFIG_FILE.tmp" "$SHELL_CONFIG_FILE"
     done
 else
     echo "Warning: $SHELL_CONFIG_FILE does not exist."
@@ -103,14 +97,8 @@ if confirm "Remove M269 custom styling from $CSS_FILE ?"; then
     if [[ -f "$CSS_FILE" ]]; then
         cp "$CSS_FILE" "$CSS_FILE".backup
         echo "Removing M269 custom styling from $CSS_FILE..."
-        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-            sed -i "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
-        elif [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i "" "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE"
-        else
-            echo "Warning: unknown OS or the OSTYPE environment variable has been changed."
-            echo "skipping removal of custom styling..."
-        fi
+        sed "/$START_DELIM/,/$END_DELIM/d" "$CSS_FILE" > "$CSS_FILE.tmp"
+        mv "$CSS_FILE.tmp" "$CSS_FILE"
     else
         echo "Warning: $CSS_FILE does not exist."
     fi


### PR DESCRIPTION
Note: The URL on [line 91](https://github.com/dsa-ou/m269-installer/blob/b9aedc372b17a11d80cb9785f3dd677ffa035219/install.sh#L91) has been changed to download from 14-create-uninstallation-scripts instead of main for testing purposes. This will need to be changed back before merging.

Another couple of points:
* The uninstall script has been added to `FILES` so will be downloaded if no arg is given. If arg is given `install.sh` will copy `uninstall.sh` to the M269 folder. So whichever way the script is run `uninstall.sh` will end up in the M269 folder; not sure if this is correct based on what the second mode is supposed to be used for.
* The messaging (echoed to the user) and general comments might need some changes for consistency with the original script and just a better "bedside manner".
* The script does _not_ delete itself at the end. For the process of reinstallation I think it would make sense to do this?