### PR TITLE
Fix #37: Add fix to Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ You can press Tab to complete commands and pathnames.
 
 5. Close the PowerShell (Windows) or terminal (Unix).
 
+**Note for macOS users**: If the `m269-23j` and `nb` commands are not working after installation, and you are using `bash`, enter:
+ ```bash
+ echo 'if [ -f ~/.bashrc ]; then source ~/.bashrc; fi' >> ~/.bash_profile
+ ```
+restart your terminal and try again.
+
 ## 4 Checking your code
 
 This section is for M269 students only. Instructions for tutors will be given separately.

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ You can press Tab to complete commands and pathnames.
 
 5. Close the PowerShell (Windows) or terminal (Unix).
 
-**Note for macOS users**: If the `m269-23j` and `nb` commands are not working after installation, and you are using `bash`, enter:
+**Note for macOS users**:
+If steps 2 and 3 (the `m269-23j` and `nb` commands) are not working,
+and you are using `bash`, enter in the terminal
  ```bash
  echo 'if [ -f ~/.bashrc ]; then source ~/.bashrc; fi' >> ~/.bash_profile
  ```
-restart your terminal and try again.
+Then close your terminal, open a new one, and try again steps 2 and 3.
 
 ## 4 Checking your code
 


### PR DESCRIPTION
Added a "Note to macOS users" to the Usage section after the main instructions.

Consider this a first draft: I am not sure if this is the correct location, or whether it adds more confusion rather than helps!