### PR TITLE
Fix #30: create Windows desktop shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,14 @@ or by double clicking a desktop shortcut. On Unix, use a terminal.
 
 ### 3.1 Desktop shortcut (Windows only)
 
-The installation script should create a shortcut on your desktop named M269-start, you can double click this shortcut to start Jupyter
-in your M269 folder. First, a PowerShell window opens where Jupyter writes its log messages,
-then your browser should open the Jupyter dashboard, listing the contents of your M269 folder.
+The installation process creates a shortcut on your desktop named `M269-start`.
+If you double click this shortcut, a PowerShell window opens where Jupyter writes its log messages,
+then your browser opens the Jupyter dashboard, listing the contents of your M269 folder.
 If there’s a message about migrating to Notebook 7, click "don’t show anymore".
 You can now continue reading Section 1.3 of the book to learn how to use Jupyter.
 
 **Note for tutors:** You can create additional shortcuts, each opening Jupyter in
-a different start folder, e.g. the eTMA marking folder by following the instructions below. 
-
-The `start.ps1` script and these instructions are originally by M269 tutor Bob Moore.
+a different start folder, e.g. the eTMA marking folder, by following these instructions:
 
 1. Right click on the desktop. Select 'new shortcut'. Type `powershell`.
    Hit 'Next' and then 'Finish': 'powershell' gets automatically expanded to the full name of the program.
@@ -102,11 +100,15 @@ The `start.ps1` script and these instructions are originally by M269 tutor Bob M
 2. Right click on the new desktop icon and select 'Properties' to update the shortcut:
 
    1. Modify the start-up folder to be your M269 folder.
-   2. Append `-file start.ps1 path/to/folder` to the target field (if the path includes spaces, you must enclose it in quotes). It should now read:
+   2. Append `-file start.ps1 path/to/folder` to the target field
+      (if the path includes spaces, you must enclose it in quotes). It should now read:
       `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -file start.ps1 path/to/folder`.
    3. Optionally you can update the icon for the shortcut. To get a Jupyter icon
       instead of a PowerShell icon you can use
-      `%USERPROFILE%\venvs\m269-23j\Lib\site-packages\nbclassic\static\base\images\favicon.ico`.
+      `%USERPROFILE%\venvs\m269-24j\Lib\site-packages\nbclassic\static\base\images\favicon.ico`.
+
+We thank M269 tutor Bob Moore for creating the original version of `start.ps1`
+and of these shortcut instructions.
 
 ### 3.2 Terminal (Windows and Unix)
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,18 @@ the software, if needed. Now proceed to the next section.
 ## 3 Usage
 
 On Windows, there are two ways of using the M269 notebooks, either from a terminal
-or by creating a desktop shortcut. On Unix, use a terminal.
+or by double clicking a desktop shortcut. On Unix, use a terminal.
 
 ### 3.1 Desktop shortcut (Windows only)
+
+The installation script should create a shortcut on your desktop named M269-start, you can double click this shortcut to start Jupyter
+in your M269 folder. First, a PowerShell window opens where Jupyter writes its log messages,
+then your browser should open the Jupyter dashboard, listing the contents of your M269 folder.
+If there’s a message about migrating to Notebook 7, click "don’t show anymore".
+You can now continue reading Section 1.3 of the book to learn how to use Jupyter.
+
+**Note for tutors:** You can create additional shortcuts, each opening Jupyter in
+a different start folder, e.g. the eTMA marking folder by following the instructions below. 
 
 The `start.ps1` script and these instructions are originally by M269 tutor Bob Moore.
 
@@ -93,22 +102,11 @@ The `start.ps1` script and these instructions are originally by M269 tutor Bob M
 2. Right click on the new desktop icon and select 'Properties' to update the shortcut:
 
    1. Modify the start-up folder to be your M269 folder.
-   2. Append `-file start.ps1` to the target field. It should now read:
-      `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -file start.ps1`.
+   2. Append `-file start.ps1 path/to/folder` to the target field (if the path includes spaces, you must enclose it in quotes). It should now read:
+      `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -file start.ps1 path/to/folder`.
    3. Optionally you can update the icon for the shortcut. To get a Jupyter icon
       instead of a PowerShell icon you can use
       `%USERPROFILE%\venvs\m269-23j\Lib\site-packages\nbclassic\static\base\images\favicon.ico`.
-
-You should now be able to double click on the desktop shortcut to start Jupyter
-in your M269 folder. First, a PowerShell window opens where Jupyter writes its log messages,
-then your browser should open the Jupyter dashboard, listing the contents of your M269 folder.
-If there’s a message about migrating to Notebook 7, click "don’t show anymore".
-You can now continue reading Section 1.3 of the book to learn how to use Jupyter.
-
-**Note for tutors:** You can create multiple shortcuts, each opening Jupyter in
-a different start folder, e.g. the eTMA marking folder. Follow the same steps
-as above for each shortcut, but in step 2.2, append also the intended start folder:
-`-file start.ps1 path/to/folder`. If the path includes spaces, you must enclose it in quotes.
 
 ### 3.2 Terminal (Windows and Unix)
 

--- a/install.ps1
+++ b/install.ps1
@@ -118,5 +118,23 @@ if (-not (Test-Path -Path $CONFIG_FILE)) {
 }
 Add-Content -Path $CONFIG_FILE -Value $ALIASES -NoNewline
 
+Write-Host "Adding desktop shortcut..."
+
+$Desktop = [System.Environment]::GetFolderPath('Desktop')
+$ShortcutPath = Join-Path $Desktop "M269-start.lnk"
+$TargetPath = "$FOLDER\start.ps1"
+
+$WScriptShell = New-Object -ComObject WScript.Shell
+$Shortcut = $WScriptShell.CreateShortcut($ShortcutPath)
+$Shortcut.TargetPath = "powershell.exe"
+$Shortcut.Arguments = "-ExecutionPolicy Bypass -File `"$TargetPath`""
+$Shortcut.Description = "Start the M269 software"
+
+# set the icon for the shortcut (using the powershell icon)
+$PowerShellExe = (Get-Command powershell.exe).Source
+$Shortcut.IconLocation = "$PowerShellExe, 0"
+
+$Shortcut.Save()
+
 Write-Host "Software has been installed."
 Write-Host "All done. Go to $SITE for further instructions."


### PR DESCRIPTION
- Add to `install.ps1`: create desktop shortcut that runs `start.ps1`
- Modify README : Windows users can run Jupyter via shortcut

At present, the name that appears under the shortcut (and is mentioned in README) is "M269-start". This is defined [here](https://github.com/dsa-ou/m269-installer/blob/a8ddec760ebea783ae3e9c59bd6d1c434046d182/install.ps1#L124) incase it needs to be changed. Similarly the description (text that appears on mouse hover) is currently "Start the M269 software" and is defined [here](https://github.com/dsa-ou/m269-installer/blob/a8ddec760ebea783ae3e9c59bd6d1c434046d182/install.ps1#L131).

When modifying the README, the original instructions (by Bob) needed  (very) minor alterations to suit the new context. It might be best for him to check that he is still happy with them since his name is mentioned.