### PR TITLE
Add newline to shell configuration file before alias entry

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,8 @@ else
     FILE=~/.${shell}rc
 fi
 
+echo >> $FILE
+
 if [ $shell = "csh" ] || [ $shell = "tcsh" ]
 then
     echo "alias $COURSE '$M269'" >> $FILE

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,7 @@ else
     FILE=~/.${shell}rc
 fi
 
+# Add a newline so that the alias doesn't concatenate with any previously existing text
 echo >> $FILE
 
 if [ $shell = "csh" ] || [ $shell = "tcsh" ]


### PR DESCRIPTION
Add a new line so that the alias does not concatenate with any previously existing text.